### PR TITLE
Revert "Build only on stable until matrix extension work"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: dart
-
+dart:
+  - stable
+  - dev


### PR DESCRIPTION
This reverts commit 2b9b111964e9f8575ff566f80e548d15faec4618.